### PR TITLE
Move xdg and fix dl client config on every container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM linuxserver/lidarr:preview
 LABEL maintainer="RandomNinjaAtk"
 
-ENV VERSION="1.5.1"
+ENV VERSION="1.5.2"
 ENV XDG_CONFIG_HOME="/xdg"
 ENV downloaddir="/downloads/deezloaderremix"
 ENV LidarrImportLocation="/downloads/lidarr-import"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM linuxserver/lidarr:preview
 LABEL maintainer="RandomNinjaAtk"
 
 ENV VERSION="1.5.1"
+ENV XDG_CONFIG_HOME="/xdg"
 ENV downloaddir="/downloads/deezloaderremix"
 ENV LidarrImportLocation="/downloads/lidarr-import"
 ENV LidarrUrl="http://127.0.0.1:8686"

--- a/root/etc/cont-init.d/02-deezloader-startup.bash
+++ b/root/etc/cont-init.d/02-deezloader-startup.bash
@@ -15,6 +15,7 @@ fi
 # remove legacy xdg directory
 if [ -d "/config/xdg" ]; then
 	rm -rf "/config/xdg"
+	sleep 0.1
 fi
 
 # create downloads directory

--- a/root/etc/cont-init.d/02-deezloader-startup.bash
+++ b/root/etc/cont-init.d/02-deezloader-startup.bash
@@ -1,7 +1,21 @@
 #!/usr/bin/with-contenv bash
 
-if [ ! -d /downloads/deezloaderremix ]; then
-	mkdir /downloads/deezloaderremix
+# remove old config
+if [ -f "/config/xdg/Deezloader Remix/config.json" ]; then
+	rm "/config/xdg/Deezloader Remix/config.json"
+	sleep 0.1
+fi
+
+# clean log folder
+if [ -d "/config/xdg/Deezloader Remix/logs" ]; then
+	rm "/config/xdg/Deezloader Remix/logs"/*
+	sleep 0.1
+fi
+
+# create downloads directory
+if [ ! -d "/downloads/deezloaderremix" ]; then
+	mkdir "/downloads/deezloaderremix"
+	chmod 0777 "/downloads/deezloaderremix"
 fi
 
 ln -sf /downloads/deezloaderremix "/root/Deezloader Music" && \

--- a/root/etc/cont-init.d/02-deezloader-startup.bash
+++ b/root/etc/cont-init.d/02-deezloader-startup.bash
@@ -1,15 +1,20 @@
 #!/usr/bin/with-contenv bash
 
 # remove old config
-if [ -f "/config/xdg/Deezloader Remix/config.json" ]; then
-	rm "/config/xdg/Deezloader Remix/config.json"
+if [ -f "/xdg/Deezloader Remix/config.json" ]; then
+	rm "/xdg/Deezloader Remix/config.json"
 	sleep 0.1
 fi
 
 # clean log folder
-if [ -d "/config/xdg/Deezloader Remix/logs" ]; then
-	rm "/config/xdg/Deezloader Remix/logs"/*
+if [ -d "/xdg/Deezloader Remix/logs" ]; then
+	rm "/xdg/Deezloader Remix/logs"/*
 	sleep 0.1
+fi
+
+# remove legacy xdg directory
+if [ -d "/config/xdg" ]; then
+	rm -rf "/config/xdg"
 fi
 
 # create downloads directory


### PR DESCRIPTION
This should prevent users from accidentally breaking the settings on the dl client and allowing it to be fixed with a simple reboot...