### PR TITLE
Update lad-setup.bash defaults

### DIFF
--- a/root/etc/cont-init.d/21-lad-setup.bash
+++ b/root/etc/cont-init.d/21-lad-setup.bash
@@ -107,13 +107,13 @@ if [ -z "$VIDEOPATH" ]; then
 	VIDEOPATH=""
 fi
 if [ -z "$AMODE" ]; then
-	AMODE=""
+	AMODE="wanted"
 fi
 if [ -z "$IMODE" ]; then
-	IMODE=""
+	IMODE="match"
 fi
 if [ -z "$DLMODE" ]; then
-	DLMODE=""
+	DLMODE="Audio"
 fi
 sed -i "s/\"queueConcurrency\": 3,/\"queueConcurrency\": $CONCURRENCY,/g" "/xdg/deemix/config.json" && \
 


### PR DESCRIPTION
Setting the defaults for AMODE, IMODE, and DLMODE to match the readme values, to avoid potential confusion / issues.  Pulled the image, started, noted errors within the output of the lad script.  Dug into the script and found that several of the variables were coming back as empty, contrary to what was implied in the readme as default assigned values.